### PR TITLE
Fix label in incidents page

### DIFF
--- a/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
@@ -22,7 +22,7 @@ export default function IncidentsPage() {
           onClick={() => setTab('closed')}
           className={`px-4 py-1 ${tab === 'closed' ? 'bg-gray-300' : ''}`}
         >
-          Historial
+          Histórico
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- correct label `Historial` to `Histórico`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6850e5bafe40833399b0f04c2c53154d