### PR TITLE
Fix duplicate MQTT listeners for WebSocket clients

### DIFF
--- a/andon-server/index.js
+++ b/andon-server/index.js
@@ -79,7 +79,6 @@ app.post('/incidents', async (req, res) => {
 
 /* ---------- WebSocket bridge ---------- */
 const wss = new WebSocketServer({ port: 8080 })
-wss.on('connection', _ws => {})
 mqttClient.on('message', (_topic, msg) => {
   for(const client of wss.clients){
     if(client.readyState === WebSocket.OPEN){

--- a/andon-server/index.js
+++ b/andon-server/index.js
@@ -7,7 +7,7 @@ const express = require('express')
 const cors    = require('cors')
 const { Pool } = require('pg')
 const mqtt   = require('mqtt')
-const { WebSocketServer } = require('ws')
+const { WebSocketServer, WebSocket } = require('ws')
 
 const app  = express()
 app.use(cors())          // cors despues de crear app
@@ -79,8 +79,13 @@ app.post('/incidents', async (req, res) => {
 
 /* ---------- WebSocket bridge ---------- */
 const wss = new WebSocketServer({ port: 8080 })
-wss.on('connection', ws => {
-  mqttClient.on('message', (_topic, msg) => ws.send(msg.toString()))
+wss.on('connection', _ws => {})
+mqttClient.on('message', (_topic, msg) => {
+  for(const client of wss.clients){
+    if(client.readyState === WebSocket.OPEN){
+      client.send(msg.toString())
+    }
+  }
 })
 mqttClient.subscribe('andon/#')
 

--- a/andon-server/index.js
+++ b/andon-server/index.js
@@ -80,11 +80,12 @@ app.post('/incidents', async (req, res) => {
 /* ---------- WebSocket bridge ---------- */
 const wss = new WebSocketServer({ port: 8080 })
 mqttClient.on('message', (_topic, msg) => {
-  for(const client of wss.clients){
-    if(client.readyState === WebSocket.OPEN){
-      client.send(msg.toString())
+  const text = msg.toString()
+  wss.clients.forEach(client => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(text)
     }
-  }
+  })
 })
 mqttClient.subscribe('andon/#')
 


### PR DESCRIPTION
## Summary
- avoid adding a new MQTT handler on each WebSocket connection
- broadcast MQTT messages to all connected WebSockets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850e5d0f1a88333a27fa6e79d287a1b