### PR TITLE
Update comment wording in server index

### DIFF
--- a/andon-server/index.js
+++ b/andon-server/index.js
@@ -1,5 +1,5 @@
 /* main backend file
-   comments without accents or letter enie */
+   comments without accents or the letter ñ */
 
 require('dotenv').config()
 


### PR DESCRIPTION
## Summary
- clarify the introductory comment wording about the letter ñ in `andon-server/index.js`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6850e5ea94ac8333a7cbaeb27839e742