### PR TITLE
Fix conflict markers and add station UI

### DIFF
--- a/andon-client/andon-dashboard/src/App.tsx
+++ b/andon-client/andon-dashboard/src/App.tsx
@@ -2,14 +2,16 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Dashboard from './components/Dashboard';
 import IncidentsPage from './pages/IncidentsPage';
 import ChartsPage from './pages/ChartsPage';
+import StationSelector from './components/StationSelector';
 
 export default function App() {
   return (
     <BrowserRouter>
-      <nav className="bg-slate-800 text-white p-2 flex gap-4">
-        <Link to="/">Dash</Link>
-        <Link to="/incidents">Incidencias</Link>
-        <Link to="/charts">Graficas</Link>
+      <nav className="bg-slate-800 text-white p-2 flex gap-4 items-center">
+        <StationSelector />
+        <Link to="/" className="px-2">Dash</Link>
+        <Link to="/incidents" className="px-2">Incidencias</Link>
+        <Link to="/charts" className="px-2">Gr\u00e1ficas</Link>
       </nav>
 
       <Routes>

--- a/andon-client/andon-dashboard/src/components/StationSelector.tsx
+++ b/andon-client/andon-dashboard/src/components/StationSelector.tsx
@@ -1,0 +1,22 @@
+import { useStations } from '../hooks/useStations';
+import { useStation } from '../contexts/StationContext';
+
+export default function StationSelector() {
+  const { data: stations } = useStations();
+  const { station, setStation } = useStation();
+  if (!stations) return null;
+  return (
+    <select
+      value={station}
+      onChange={e => setStation(e.target.value)}
+      className="border px-2 py-1 rounded"
+    >
+      <option value="">Estaci\u00f3n</option>
+      {stations.map((s: any) => (
+        <option key={s.id} value={s.id}>
+          {s.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
@@ -1,8 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { FormEvent, useState } from 'react';
+import { useState, useEffect } from 'react';
+import type { FormEvent } from 'react';
+import { useStation } from '../../contexts/StationContext';
 
 export default function IncidentForm() {
+  const { station } = useStation();
   const { data: stations } = useQuery({
     queryKey: ['stations'],
     queryFn: () => axios.get('/stations').then(r => r.data)
@@ -13,10 +16,14 @@ export default function IncidentForm() {
   });
 
   const [form, setForm] = useState({
-    station_id: '',
+    station_id: station,
     defect_code: '',
     vehicle_id: ''
   });
+
+  useEffect(() => {
+    setForm(f => ({ ...f, station_id: station }));
+  }, [station]);
 
   const handle = (e: any) =>
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -29,20 +36,25 @@ export default function IncidentForm() {
 
   return (
     <form onSubmit={submit} className="space-y-2 border p-4 rounded mt-4">
-      <select
-        required
-        name="station_id"
-        value={form.station_id}
-        onChange={handle}
-        className="border p-1 w-full"
-      >
-        <option value="">Estacion</option>
-        {stations?.map((s: any) => (
-          <option key={s.id} value={s.id}>
-            {s.name}
-          </option>
-        ))}
-      </select>
+      {station === '' && (
+        <select
+          required
+          name="station_id"
+          value={form.station_id}
+          onChange={handle}
+          className="border p-1 w-full"
+        >
+          <option value="">Estaci\u00f3n</option>
+          {stations?.map((s: any) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+      )}
+      {station !== '' && (
+        <input type="hidden" name="station_id" value={form.station_id} />
+      )}
 
       <select
         required

--- a/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
@@ -1,7 +1,9 @@
 import { useIncidents, useCloseIncident } from '../../hooks/useIncidents';
+import { useStation } from '../../contexts/StationContext';
 
 export default function IncidentTable({ status }: { status: string }) {
-  const { data } = useIncidents(status);
+  const { station } = useStation();
+  const { data } = useIncidents(status, station);
   const close   = useCloseIncident();
 
   if (!data) return <p>Cargando...</p>;

--- a/andon-client/andon-dashboard/src/contexts/StationContext.tsx
+++ b/andon-client/andon-dashboard/src/contexts/StationContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+interface StationCtx {
+  station: string;
+  setStation: (id: string) => void;
+}
+
+const StationContext = createContext<StationCtx | undefined>(undefined);
+
+export function StationProvider({ children }: { children: ReactNode }) {
+  const [station, setStation] = useState('');
+  return (
+    <StationContext.Provider value={{ station, setStation }}>
+      {children}
+    </StationContext.Provider>
+  );
+}
+
+export function useStation() {
+  const ctx = useContext(StationContext);
+  if (!ctx) throw new Error('useStation must be used within StationProvider');
+  return ctx;
+}

--- a/andon-client/andon-dashboard/src/hooks/useIncidents.ts
+++ b/andon-client/andon-dashboard/src/hooks/useIncidents.ts
@@ -2,12 +2,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 
-export const useIncidents = (status:string='open') =>
+export const useIncidents = (status: string = 'open', station?: string) =>
   useQuery({
-    queryKey: ['incidents', status],
+    queryKey: ['incidents', status, station],
     queryFn: async () => {
       const { data } = await axios.get(`/incidents?status=${status}`);
-      return data;
+      return station ? data.filter((i: any) => String(i.station_id) === station) : data;
     }
   });
 
@@ -15,6 +15,6 @@ export const useCloseIncident = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id:number) => axios.patch(`/incidents/${id}/close`),
-    onSuccess: () => qc.invalidateQueries({ queryKey:['incidents','open'] })
+    onSuccess: () => qc.invalidateQueries({ queryKey:['incidents'] })
   });
 };

--- a/andon-client/andon-dashboard/src/hooks/useMqtt.ts
+++ b/andon-client/andon-dashboard/src/hooks/useMqtt.ts
@@ -14,6 +14,8 @@ export const useMqtt = (
         cb({ topic: tp, payload: JSON.parse(buf.toString()) });
       } catch { /* ignore */ }
     });
-    return () => client.end();
+    return () => {
+      client.end();
+    };
   }, [topic, cb]);
 };

--- a/andon-client/andon-dashboard/src/main.tsx
+++ b/andon-client/andon-dashboard/src/main.tsx
@@ -4,13 +4,16 @@ import App from './App.tsx';
 import './index.css';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StationProvider } from './contexts/StationContext';
 
 const qc = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <App />
+      <StationProvider>
+        <App />
+      </StationProvider>
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/andon-client/andon-dashboard/src/pages/ChartsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/ChartsPage.tsx
@@ -2,9 +2,11 @@
 // grafica simple de incidencias por estacion usando Recharts
 import { useIncidents } from '../hooks/useIncidents';
 import { PieChart, Pie, Cell, Tooltip } from 'recharts';
+import { useStation } from '../contexts/StationContext';
 
 export default function ChartsPage() {
-  const { data, isLoading } = useIncidents('all');
+  const { station } = useStation();
+  const { data, isLoading } = useIncidents('all', station);
 
   if (isLoading) return <p>Cargando...</p>;
   if (!data?.length) return <p>No hay datos.</p>;

--- a/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
@@ -1,13 +1,18 @@
 import IncidentForm from '../components/incidents/IncidentForm';
 import IncidentTable from '../components/incidents/IncidentTable';
 import { useState } from 'react';
+import { useStation } from '../contexts/StationContext';
 
 export default function IncidentsPage() {
   const [tab, setTab] = useState<'open' | 'closed'>('open');
+  const { station } = useStation();
 
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-2">Incidencias</h1>
+      {station === '' && (
+        <p className="text-red-600">Selecciona una estaci\u00f3n para operar.</p>
+      )}
 
       <IncidentForm />
 

--- a/andon-server/index.js
+++ b/andon-server/index.js
@@ -79,21 +79,14 @@ app.post('/incidents', async (req, res) => {
 
 /* ---------- WebSocket bridge ---------- */
 const wss = new WebSocketServer({ port: 8080 })
-/<<<<<<< 7q5c56-codex/modify-websocket-setup-and-mqtt-handling
+
+// forward MQTT messages to all connected websocket clients
 mqttClient.on('message', (_topic, msg) => {
   const text = msg.toString()
   wss.clients.forEach(client => {
     if (client.readyState === WebSocket.OPEN) {
       client.send(text)
     }
-=======
-
-// forward MQTT messages to all connected websocket clients
-mqttClient.on('message', (_topic, msg) => {
-  const data = msg.toString()
-  wss.clients.forEach(client => {
-    if (client.readyState === client.OPEN) client.send(data)
-/>>>>>>> main
   })
 })
 mqttClient.subscribe('andon/#')


### PR DESCRIPTION
## Summary
- remove leftover merge markers in server websocket bridge
- support station selection and filtering on the dashboard UI
- wrap the frontend in a provider to share current station
- filter incident lists and charts by station

## Testing
- `npm test --prefix andon-server`
- `npm run build` in `andon-client/andon-dashboard`


------
https://chatgpt.com/codex/tasks/task_e_6850f20c25b48333bbfdb5f2e0d6abc1