### PR TITLE
Add realtime incident sync via MQTT

### DIFF
--- a/andon-client/andon-dashboard/src/hooks/useIncidentSync.ts
+++ b/andon-client/andon-dashboard/src/hooks/useIncidentSync.ts
@@ -1,0 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { useMqtt } from './useMqtt';
+
+export const useIncidentSync = () => {
+  const qc = useQueryClient();
+  const handle = useCallback(() => {
+    qc.invalidateQueries({ queryKey: ['incidents'] });
+  }, [qc]);
+
+  useMqtt('andon/incidents/+', handle);
+};

--- a/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
@@ -2,10 +2,12 @@ import IncidentForm from '../components/incidents/IncidentForm';
 import IncidentTable from '../components/incidents/IncidentTable';
 import { useState } from 'react';
 import { useStation } from '../contexts/StationContext';
+import { useIncidentSync } from '../hooks/useIncidentSync';
 
 export default function IncidentsPage() {
   const [tab, setTab] = useState<'open' | 'closed'>('open');
   const { station } = useStation();
+  useIncidentSync();
 
   return (
     <div className="p-4">


### PR DESCRIPTION
## Summary
- implement `useIncidentSync` hook to listen to MQTT updates
- refresh incidents list when new or updated incidents are published
- use the hook in `IncidentsPage` for automatic updates

## Testing
- `npm test` in `andon-server`
- `npm test` in `andon-client/andon-dashboard` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850f64343ac8333bd2df33a89a675d4