### PR TITLE
Add action dropdown for incidents

### DIFF
--- a/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
@@ -1,10 +1,10 @@
-import { useIncidents, useCloseIncident } from '../../hooks/useIncidents';
+import { useIncidents, useIncidentAction } from '../../hooks/useIncidents';
 import { useStation } from '../../contexts/StationContext';
 
 export default function IncidentTable({ status }: { status: string }) {
   const { station } = useStation();
   const { data } = useIncidents(status, station);
-  const close   = useCloseIncident();
+  const action  = useIncidentAction();
 
   if (!data) return <p>Cargando...</p>;
 
@@ -26,12 +26,19 @@ export default function IncidentTable({ status }: { status: string }) {
             <td>{new Date(i.opened_at).toLocaleTimeString()}</td>
             <td>
               {i.status === 'open' && (
-                <button
-                  onClick={() => close.mutate(i.id)}
-                  className="bg-green-600 text-white px-2"
+                <select
+                  defaultValue=""
+                  onChange={e => {
+                    const val = e.target.value;
+                    if(val) action.mutate({ id: i.id, action: val });
+                  }}
+                  className="border p-1"
                 >
-                  Cerrar
-                </button>
+                  <option value="">Accion</option>
+                  <option value="finalizado">finalizado</option>
+                  <option value="reproceso">reproceso</option>
+                  <option value="recibido">recibido</option>
+                </select>
               )}
             </td>
           </tr>

--- a/andon-client/andon-dashboard/src/hooks/useIncidents.ts
+++ b/andon-client/andon-dashboard/src/hooks/useIncidents.ts
@@ -18,3 +18,12 @@ export const useCloseIncident = () => {
     onSuccess: () => qc.invalidateQueries({ queryKey:['incidents'] })
   });
 };
+
+export const useIncidentAction = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, action }: { id:number; action:string }) =>
+      axios.patch(`/incidents/${id}/action`, { action }),
+    onSuccess: () => qc.invalidateQueries({ queryKey:['incidents'] })
+  });
+};

--- a/andon-server/tests/incidents.test.js
+++ b/andon-server/tests/incidents.test.js
@@ -40,4 +40,26 @@ describe('/incidents endpoints', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(closed);
   });
+
+  test('PATCH /incidents/:id/action finalizado closes incident', async () => {
+    const before = { id: 1, station_id: 1 };
+    const after  = { id: 1, station_id: 1, status: 'closed' };
+    mPool.query
+      .mockResolvedValueOnce({ rows: [before] })
+      .mockResolvedValueOnce({ rows: [after] });
+    const res = await request(app)
+      .patch('/incidents/1/action')
+      .send({ action: 'finalizado' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(after);
+  });
+
+  test('PATCH /incidents/:id/action invalid action returns 400', async () => {
+    const inc = { id: 1, station_id: 1 };
+    mPool.query.mockResolvedValueOnce({ rows: [inc] });
+    const res = await request(app)
+      .patch('/incidents/1/action')
+      .send({ action: 'foo' });
+    expect(res.statusCode).toBe(400);
+  });
 });


### PR DESCRIPTION
## Summary
- allow updating incident state via `/incidents/:id/action`
- update tests for new endpoint
- add useIncidentAction hook for dashboard
- show dropdown in incident table to select action

## Testing
- `npm test` in `andon-server`
- `npm run build` in `andon-client/andon-dashboard`

------
https://chatgpt.com/codex/tasks/task_e_68520523f7e88333ba080984756502be