### PR TITLE
Update dashboard forms and tracking

### DIFF
--- a/andon-client/andon-dashboard/src/App.tsx
+++ b/andon-client/andon-dashboard/src/App.tsx
@@ -1,23 +1,29 @@
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Link, useLocation } from 'react-router-dom';
 import Dashboard from './components/Dashboard';
 import IncidentsPage from './pages/IncidentsPage';
 import ChartsPage from './pages/ChartsPage';
 import StationSelector from './components/StationSelector';
 
+function Nav() {
+  const loc = useLocation();
+  return (
+    <nav className="bg-slate-800 text-white p-2 flex gap-4 items-center">
+      {loc.pathname !== '/' && <StationSelector />}
+      <Link to="/" className="px-2">Dash</Link>
+      <Link to="/incidents" className="px-2">Incidencias</Link>
+      <Link to="/charts" className="px-2">GRAFICAS</Link>
+    </nav>
+  );
+}
+
 export default function App() {
   return (
     <BrowserRouter>
-      <nav className="bg-slate-800 text-white p-2 flex gap-4 items-center">
-        <StationSelector />
-        <Link to="/" className="px-2">Dash</Link>
-        <Link to="/incidents" className="px-2">Incidencias</Link>
-        <Link to="/charts" className="px-2">Gr\u00e1ficas</Link>
-      </nav>
-
+      <Nav />
       <Routes>
-        <Route path="/"        element={<Dashboard />} />
+        <Route path="/" element={<Dashboard />} />
         <Route path="/incidents" element={<IncidentsPage />} />
-        <Route path="/charts"   element={<ChartsPage />} />
+        <Route path="/charts" element={<ChartsPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/andon-client/andon-dashboard/src/components/StationSelector.tsx
+++ b/andon-client/andon-dashboard/src/components/StationSelector.tsx
@@ -11,7 +11,7 @@ export default function StationSelector() {
       onChange={e => setStation(e.target.value)}
       className="border px-2 py-1 rounded"
     >
-      <option value="">Estaci\u00f3n</option>
+      <option value="">ESTACION</option>
       {stations.map((s: any) => (
         <option key={s.id} value={s.id}>
           {s.name}

--- a/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
@@ -12,7 +12,7 @@ export default function IncidentTable({ status }: { status: string }) {
     <table className="w-full border mt-2">
       <thead>
         <tr>
-          <th>ID</th><th>Estacion</th><th>Defecto</th>
+          <th>ID</th><th>ESTACION</th><th>Defecto</th>
           <th>Vehiculo</th><th>Abierto</th><th>Accion</th>
         </tr>
       </thead>
@@ -37,7 +37,6 @@ export default function IncidentTable({ status }: { status: string }) {
                   <option value="">Accion</option>
                   <option value="finalizado">finalizado</option>
                   <option value="reproceso">reproceso</option>
-                  <option value="recibido">recibido</option>
                 </select>
               )}
             </td>

--- a/andon-client/andon-dashboard/src/pages/ChartsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/ChartsPage.tsx
@@ -1,19 +1,30 @@
 // ChartsPage.tsx
 // grafica simple de incidencias por estacion usando Recharts
 import { useIncidents } from '../hooks/useIncidents';
-import { PieChart, Pie, Cell, Tooltip } from 'recharts';
+import { PieChart, Pie, Cell, Tooltip, BarChart, Bar, XAxis, YAxis } from 'recharts';
 import { useStation } from '../contexts/StationContext';
+import { useState } from 'react';
 
 export default function ChartsPage() {
   const { station } = useStation();
   const { data, isLoading } = useIncidents('all', station);
+  const [range, setRange] = useState<'all' | '24h' | '7d'>('all');
+  const [type, setType]   = useState<'pie' | 'bar'>('pie');
 
   if (isLoading) return <p>Cargando...</p>;
   if (!data?.length) return <p>No hay datos.</p>;
 
+  const now = Date.now();
+  const filtered = data.filter((i: any) => {
+    const t = new Date(i.opened_at).getTime();
+    if(range === '24h') return now - t <= 86400000;
+    if(range === '7d')  return now - t <= 604800000;
+    return true;
+  });
+
   // cuenta incidencias por estacion
   const counts: Record<string, number> = {};
-  data.forEach((i: any) =>
+  filtered.forEach((i: any) =>
     counts[i.station_id] = (counts[i.station_id] || 0) + 1
   );
 
@@ -21,13 +32,32 @@ export default function ChartsPage() {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Incidencias por estacion</h1>
-      <PieChart width={400} height={300}>
-        <Pie data={chartData} dataKey="value" nameKey="name" outerRadius={120}>
-          {chartData.map((_, idx) => <Cell key={idx} />)}
-        </Pie>
-        <Tooltip />
-      </PieChart>
+      <h1 className="text-xl font-bold mb-4">Incidencias por ESTACION</h1>
+      <div className="flex gap-2 mb-4">
+        <select value={range} onChange={e => setRange(e.target.value as any)} className="border p-1">
+          <option value="all">Todas</option>
+          <option value="24h">\u00dAltimas 24h</option>
+          <option value="7d">\u00dAltima semana</option>
+        </select>
+        <select value={type} onChange={e => setType(e.target.value as any)} className="border p-1">
+          <option value="pie">Pastel</option>
+          <option value="bar">Barras</option>
+        </select>
+      </div>
+      {type === 'pie' ? (
+        <PieChart width={400} height={300}>
+          <Pie data={chartData} dataKey="value" nameKey="name" outerRadius={120}>
+            {chartData.map((_, idx) => <Cell key={idx} />)}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      ) : (
+        <BarChart width={400} height={300} data={chartData}>
+          <XAxis dataKey="name" /><YAxis />
+          <Tooltip />
+          <Bar dataKey="value" />
+        </BarChart>
+      )}
     </div>
   );
 }

--- a/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
@@ -13,7 +13,7 @@ export default function IncidentsPage() {
     <div className="p-4">
       <h1 className="text-xl font-bold mb-2">Incidencias</h1>
       {station === '' && (
-        <p className="text-red-600">Selecciona una estaci\u00f3n para operar.</p>
+        <p className="text-red-600">Selecciona una ESTACION para operar.</p>
       )}
 
       <IncidentForm />

--- a/andon-server/index.js
+++ b/andon-server/index.js
@@ -70,6 +70,13 @@ app.patch('/incidents/:id/action', async (req, res) => {
     return res.json(upd)
   }
 
+  if(action === 'reproceso')
+    await pool.query(
+      'UPDATE incident SET reprocess_at=NOW() WHERE id=$1', [id])
+  else if(action === 'recibido')
+    await pool.query(
+      'UPDATE incident SET received_at=NOW() WHERE id=$1', [id])
+
   const color = action === 'reproceso'
     ? 'amarillo'
     : action === 'recibido'
@@ -97,8 +104,9 @@ app.get('/defects', async (_req, res) => {
 app.post('/incidents', async (req, res) => {
   const { station_id, defect_code, vehicle_id } = req.body
   const { rows } = await pool.query(
-    `INSERT INTO incident (station_id, defect_code, vehicle_id)
-     VALUES ($1,$2,$3) RETURNING *`,
+    `INSERT INTO incident (
+       station_id, defect_code, vehicle_id, received_at
+     ) VALUES ($1,$2,$3,NOW()) RETURNING *`,
     [station_id, defect_code, vehicle_id]
   )
   const inc = rows[0]

--- a/andon-server/tests/incidents.test.js
+++ b/andon-server/tests/incidents.test.js
@@ -22,7 +22,14 @@ describe('/incidents endpoints', () => {
   });
 
   test('POST /incidents creates an incident', async () => {
-    const newInc = { id: 2, station_id: 1, defect_code: 'A', vehicle_id: 'V2', status: 'open' };
+    const newInc = {
+      id: 2,
+      station_id: 1,
+      defect_code: 'A',
+      vehicle_id: 'V2',
+      status: 'open',
+      received_at: 'now'
+    };
     mPool.query.mockResolvedValueOnce({ rows: [newInc] });
     const res = await request(app).post('/incidents').send({
       station_id: 1,


### PR DESCRIPTION
## Summary
- adjust station selector text
- add current/report station logic
- restrict incident actions and auto mark as received
- hide station dropdown on Dash and rename charts link
- track timestamps in incident API
- extend charts page with filters
- update unit tests

## Testing
- `npm --prefix andon-server install`
- `npm --prefix andon-server test`

------
https://chatgpt.com/codex/tasks/task_e_68520afc57d08333ad4bb0fab0c1f6e5