### PR TITLE
Add ESP32 template and DB setup script

### DIFF
--- a/db/setup.sql
+++ b/db/setup.sql
@@ -1,0 +1,33 @@
+-- Example schema for Andon system
+CREATE TABLE IF NOT EXISTS station (
+  id   SERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS defect_code (
+  code        TEXT PRIMARY KEY,
+  station_id  INTEGER REFERENCES station(id),
+  description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS incident (
+  id          SERIAL PRIMARY KEY,
+  station_id  INTEGER REFERENCES station(id),
+  defect_code TEXT REFERENCES defect_code(code),
+  vehicle_id  TEXT,
+  status      TEXT DEFAULT 'open',
+  opened_at   TIMESTAMP DEFAULT NOW(),
+  received_at TIMESTAMP,
+  reprocess_at TIMESTAMP,
+  closed_at   TIMESTAMP
+);
+
+-- Sample stations
+INSERT INTO station (name) VALUES ('ESTACION 1'), ('ESTACION 2')
+  ON CONFLICT DO NOTHING;
+
+-- Sample defect codes per station
+INSERT INTO defect_code (code, station_id, description) VALUES
+  ('A1', 1, 'Defecto est1 A1'),
+  ('B1', 1, 'Defecto est1 B1'),
+  ('A2', 2, 'Defecto est2 A2');

--- a/esp32/station_template.ino
+++ b/esp32/station_template.ino
@@ -1,0 +1,60 @@
+#include <WiFi.h>
+#include <PubSubClient.h>
+
+// Replace with your WiFi credentials
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASS";
+
+// MQTT broker
+const char* mqttServer = "MQTT_BROKER_IP"; // e.g. 192.168.137.149
+const int   mqttPort   = 1883;
+
+// Unique station id
+const char* STATION_ID = "1"; // change per station
+
+WiFiClient espClient;
+PubSubClient client(espClient);
+
+void setupWiFi() {
+  delay(10);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+}
+
+void callback(char* topic, byte* payload, unsigned int length) {
+  payload[length] = '\0';
+  String msg = String((char*)payload);
+  if (msg == "rojo") {
+    // TODO: turn on red light
+  } else if (msg == "amarillo") {
+    // TODO: turn on yellow light
+  } else if (msg == "verde") {
+    // TODO: turn on green light
+  }
+}
+
+void reconnect() {
+  while (!client.connected()) {
+    if (client.connect(STATION_ID)) {
+      String topic = String("andon/station/") + STATION_ID + "/state";
+      client.subscribe(topic.c_str());
+    } else {
+      delay(5000);
+    }
+  }
+}
+
+void setup() {
+  setupWiFi();
+  client.setServer(mqttServer, mqttPort);
+  client.setCallback(callback);
+}
+
+void loop() {
+  if (!client.connected()) {
+    reconnect();
+  }
+  client.loop();
+}


### PR DESCRIPTION
## Summary
- add a template `.ino` sketch for ESP32 stations
- provide example PostgreSQL `setup.sql` for creating tables and seed data

## Testing
- `npm install` and `npm run lint` in andon-dashboard
- `npm install` and `npm test` in andon-server

------
https://chatgpt.com/codex/tasks/task_e_685231756c6c833386ce66a022e9e6fc