### PR TITLE
Add vehicle issue detail to incidents

### DIFF
--- a/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
@@ -18,7 +18,8 @@ export default function IncidentForm() {
   const [form, setForm] = useState({
     station_id: '',
     defect_code: '',
-    vehicle_id: ''
+    vehicle_id: '',
+    problem: ''
   });
 
   const handle = (e: any) =>
@@ -27,7 +28,7 @@ export default function IncidentForm() {
   const submit = async (e: FormEvent) => {
     e.preventDefault();
     await axios.post('/incidents', form);
-    setForm({ station_id: '', defect_code: '', vehicle_id: '' });
+    setForm({ station_id: '', defect_code: '', vehicle_id: '', problem: '' });
   };
 
   return (
@@ -88,6 +89,14 @@ export default function IncidentForm() {
         name="vehicle_id"
         placeholder="Vehiculo ID"
         value={form.vehicle_id}
+        onChange={handle}
+        className="border p-1 w-full"
+      />
+
+      <textarea
+        name="problem"
+        placeholder="Detalle del problema"
+        value={form.problem}
         onChange={handle}
         className="border p-1 w-full"
       />

--- a/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
@@ -13,7 +13,8 @@ export default function IncidentTable({ status }: { status: string }) {
       <thead>
         <tr>
           <th>ID</th><th>ESTACION</th><th>Defecto</th>
-          <th>Vehiculo</th><th>Abierto</th><th>Accion</th>
+          <th>Vehiculo</th><th>Problema</th>
+          <th>Reporte</th><th>Reproceso</th><th>Finalizado</th><th>Accion</th>
         </tr>
       </thead>
       <tbody>
@@ -23,7 +24,10 @@ export default function IncidentTable({ status }: { status: string }) {
             <td>{i.station_id}</td>
             <td>{i.defect_code}</td>
             <td>{i.vehicle_id}</td>
-            <td>{new Date(i.opened_at).toLocaleTimeString()}</td>
+            <td>{i.problem}</td>
+            <td>{i.opened_at && new Date(i.opened_at).toLocaleString()}</td>
+            <td>{i.reprocess_at && new Date(i.reprocess_at).toLocaleString()}</td>
+            <td>{i.closed_at && new Date(i.closed_at).toLocaleString()}</td>
             <td>
               {i.status === 'open' && (
                 <select

--- a/andon-server/index.js
+++ b/andon-server/index.js
@@ -102,12 +102,12 @@ app.get('/defects', async (_req, res) => {
 })
 
 app.post('/incidents', async (req, res) => {
-  const { station_id, defect_code, vehicle_id } = req.body
+  const { station_id, defect_code, vehicle_id, problem } = req.body
   const { rows } = await pool.query(
     `INSERT INTO incident (
-       station_id, defect_code, vehicle_id, received_at
-     ) VALUES ($1,$2,$3,NOW()) RETURNING *`,
-    [station_id, defect_code, vehicle_id]
+       station_id, defect_code, vehicle_id, problem, received_at
+     ) VALUES ($1,$2,$3,$4,NOW()) RETURNING *`,
+    [station_id, defect_code, vehicle_id, problem]
   )
   const inc = rows[0]
   mqttClient.publish('andon/incidents/new', JSON.stringify(inc))

--- a/andon-server/tests/incidents.test.js
+++ b/andon-server/tests/incidents.test.js
@@ -27,6 +27,7 @@ describe('/incidents endpoints', () => {
       station_id: 1,
       defect_code: 'A',
       vehicle_id: 'V2',
+      problem: 'falla motor',
       status: 'open',
       received_at: 'now'
     };
@@ -34,7 +35,8 @@ describe('/incidents endpoints', () => {
     const res = await request(app).post('/incidents').send({
       station_id: 1,
       defect_code: 'A',
-      vehicle_id: 'V2'
+      vehicle_id: 'V2',
+      problem: 'falla motor'
     });
     expect(res.statusCode).toBe(201);
     expect(res.body).toEqual(newInc);

--- a/db/setup.sql
+++ b/db/setup.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS incident (
   station_id  INTEGER REFERENCES station(id),
   defect_code TEXT REFERENCES defect_code(code),
   vehicle_id  TEXT,
+  problem     TEXT,
   status      TEXT DEFAULT 'open',
   opened_at   TIMESTAMP DEFAULT NOW(),
   received_at TIMESTAMP,


### PR DESCRIPTION
## Summary
- let users record vehicle problem details when reporting incidents
- show report, reprocess, and finalization dates in the incidents table
- extend database and API for new `problem` field
- update tests

## Testing
- `npm test --prefix andon-server`
- `npm run lint --prefix andon-client/andon-dashboard`

------
https://chatgpt.com/codex/tasks/task_e_685239536f948333a8dd886072fde16e