### PR TITLE
Add deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Sistema Andon
+
+Este proyecto implementa un sistema Andon completo compuesto por:
+
+- **Backend** Node.js que expone una API REST y puentea eventos MQTT a WebSocket.
+- **Dashboard** React para visualizar y operar incidencias en tiempo real.
+- **Firmware** para ESP32 que escucha el estado de su estación vía MQTT.
+- **Base de datos** PostgreSQL y corredor MQTT Mosquitto.
+
+Los IDs de las estaciones son fijos: `A1, B1, C1, C2, C3, C4, C5`. Los únicos
+estados permitidos son `verde`, `rojo` y `amarillo`.
+
+## Puesta en marcha en Raspberry Pi 5
+
+### 1 – Instalar servicios
+```bash
+sudo apt update
+sudo apt install -y git nodejs npm postgresql mosquitto mosquitto-clients
+```
+
+### 2 – Crear usuario y base de datos
+```bash
+sudo -u postgres psql <<'SQL'
+CREATE USER andon WITH PASSWORD 'soader98HG';
+CREATE DATABASE andon OWNER andon;
+SQL
+```
+
+### 3 – Configurar Mosquitto
+Edita `/etc/mosquitto/mosquitto.conf` y asegura al menos:
+```
+listener 1883
+allow_anonymous true
+persistence true
+persistence_location /var/lib/mosquitto/
+```
+Reinicia el servicio con `sudo systemctl restart mosquitto`.
+
+### 4 – Cargar el esquema SQL
+```bash
+psql -U andon -d andon -f db/setup.sql
+```
+
+### 5 – Back‑end
+1. Copia `.env` en `andon-server` con:
+   ```
+   PG_URL=postgresql://andon:soader98HG@localhost:5432/andon
+   MQTT_URL=mqtt://localhost:1883
+   PORT=3000
+   ```
+2. Instala dependencias y ejecuta pruebas:
+   ```bash
+   cd andon-server
+   npm install
+   npm test
+   ```
+3. Inicia la API:
+   ```bash
+   node index.js
+   ```
+
+### 6 – Front‑end
+```bash
+cd andon-client/andon-dashboard
+npm install
+npm run dev      # modo desarrollo
+# o
+npm run build    # genera `dist/` para producción
+```
+Sirve el directorio `dist/` con cualquier servidor estático (por ejemplo
+`npx serve dist`).
+
+### 7 – Firmware ESP32
+1. Ajusta `ssid`, `password`, `mqttServer` y `STATION_ID` en
+   `esp32/station_template.ino`.
+2. Compila y graba el programa en cada ESP32 con el ID correspondiente.
+
+### 8 – Sincronización
+Todos los navegadores conectados al dashboard y los ESP32 recibirán actualizaciones
+en tiempo real a través de WebSocket y MQTT. Al cerrar una incidencia, el servidor
+publica `{color:'verde'}` en `andon/station/<ID>/state` para apagar la baliza.
+
+---
+
+Con estos pasos el sistema queda listo para operar en la Raspberry Pi 5.


### PR DESCRIPTION
## Summary
- create a project-wide README describing Raspberry Pi setup

## Testing
- `npm test` in `andon-server`
- `npm run build` in `andon-client/andon-dashboard`


------
https://chatgpt.com/codex/tasks/task_e_6852e41f1ea08333be43f95371b1c577