### PR TITLE
Add env-configurable API and WebSocket URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ npm run dev      # modo desarrollo
 # o
 npm run build    # genera `dist/` para producción
 ```
+Por defecto, el dashboard se comunica con la API en `http://localhost:3000`
+y con el WebSocket en `ws://localhost:8080`. Puedes ajustar estas URL
+creando un archivo `.env` en `andon-client/andon-dashboard` con:
+```
+VITE_API_URL=http://localhost:3000
+VITE_WS_URL=ws://localhost:8080
+```
 Sirve el directorio `dist/` con cualquier servidor estático (por ejemplo
 `npx serve dist`).
 

--- a/andon-client/andon-dashboard/src/api.ts
+++ b/andon-client/andon-dashboard/src/api.ts
@@ -1,0 +1,3 @@
+import axios from 'axios';
+axios.defaults.baseURL = import.meta.env.VITE_API_URL || '';
+export default axios;

--- a/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
+import axios from '../../api';
 import { useState } from 'react';
 import type { FormEvent } from 'react';
 import { useStation } from '../../contexts/StationContext';

--- a/andon-client/andon-dashboard/src/hooks/useIncidents.ts
+++ b/andon-client/andon-dashboard/src/hooks/useIncidents.ts
@@ -1,6 +1,6 @@
 // useIncidents.ts
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import axios from '../api';
 
 export const useIncidents = (status: string = 'open', station?: string) =>
   useQuery({

--- a/andon-client/andon-dashboard/src/hooks/useMqtt.ts
+++ b/andon-client/andon-dashboard/src/hooks/useMqtt.ts
@@ -19,7 +19,9 @@ export const useMqtt = (
   cb: (msg: { topic: string; payload: any }) => void
 ) => {
   useEffect(() => {
-    const ws = new WebSocket('ws://' + location.hostname + ':8080');
+    const url =
+      import.meta.env.VITE_WS_URL || `ws://${location.hostname}:8080`;
+    const ws = new WebSocket(url);
     ws.onmessage = ev => {
       try {
         const msg = JSON.parse(ev.data);

--- a/andon-client/andon-dashboard/src/hooks/useStations.ts
+++ b/andon-client/andon-dashboard/src/hooks/useStations.ts
@@ -1,7 +1,7 @@
 // useStations.ts
 // obtiene estaciones via REST
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
+import axios from '../api';
 
 export const useStations = () =>
   useQuery({


### PR DESCRIPTION
## Summary
- expose API & WS endpoints through env vars in dashboard
- document dashboard `.env` setup

## Testing
- `npm run lint` in `andon-client/andon-dashboard`
- `npm test` in `andon-server`


------
https://chatgpt.com/codex/tasks/task_e_6852f10a13748333a72ea82862a06f8d