### PR TITLE
Fix missing problem column in DB setup script

### DIFF
--- a/db/setup.sql
+++ b/db/setup.sql
@@ -23,6 +23,10 @@ CREATE TABLE IF NOT EXISTS incident (
   closed_at   TIMESTAMP
 );
 
+-- Ensure newer columns exist when re-running the script
+ALTER TABLE incident
+  ADD COLUMN IF NOT EXISTS problem TEXT;
+
 -- Sample stations
 INSERT INTO station (name) VALUES ('ESTACION 1'), ('ESTACION 2')
   ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- ensure `problem` column is added when running `db/setup.sql`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852f6f5364083339a3c5a7aa5130e27