### PR TITLE
Fix incident reporting

### DIFF
--- a/andon-client/andon-dashboard/src/api.ts
+++ b/andon-client/andon-dashboard/src/api.ts
@@ -1,3 +1,5 @@
 import axios from 'axios';
-axios.defaults.baseURL = import.meta.env.VITE_API_URL || '';
+// default to backend on localhost when no VITE_API_URL provided
+axios.defaults.baseURL =
+  import.meta.env.VITE_API_URL || `http://localhost:3000`;
 export default axios;

--- a/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
@@ -25,8 +25,18 @@ export default function IncidentForm() {
 
   const submit = async (e: FormEvent) => {
     e.preventDefault();
-    await axios.post('/incidents', form);
-    setForm({ station_id: '', defect_code: '', vehicle_id: '', problem: '' });
+    try {
+      await axios.post('/incidents', form);
+      setForm({
+        station_id: '',
+        defect_code: '',
+        vehicle_id: '',
+        problem: ''
+      });
+    } catch (err) {
+      alert('Error al reportar incidencia');
+      console.error(err);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- default API URL to localhost
- catch errors when submitting incidents

## Testing
- `cd andon-server && npm test`
- `cd andon-client/andon-dashboard && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685305ce62108333ad5fde84e2ef3c61