### PR TITLE
Fix remote access & station selector duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,13 @@ npm run dev      # modo desarrollo
 # o
 npm run build    # genera `dist/` para producción
 ```
-Por defecto, el dashboard se comunica con la API en `http://localhost:3000`
-y con el WebSocket en `ws://localhost:8080`. Puedes ajustar estas URL
-creando un archivo `.env` en `andon-client/andon-dashboard` con:
+Por defecto, el dashboard contacta la API y el WebSocket en la misma
+dirección donde se sirve la página (puertos `3000` y `8080`). Si tu
+backend está en otra IP o puerto, crea un archivo `.env` en
+`andon-client/andon-dashboard` con por ejemplo:
 ```
-VITE_API_URL=http://localhost:3000
-VITE_WS_URL=ws://localhost:8080
+VITE_API_URL=http://mi-servidor:3000
+VITE_WS_URL=ws://mi-servidor:8080
 ```
 Sirve el directorio `dist/` con cualquier servidor estático (por ejemplo
 `npx serve dist`).

--- a/andon-client/andon-dashboard/src/api.ts
+++ b/andon-client/andon-dashboard/src/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
-// default to backend on localhost when no VITE_API_URL provided
+// default to same host as the dashboard when no VITE_API_URL provided
 axios.defaults.baseURL =
-  import.meta.env.VITE_API_URL || `http://localhost:3000`;
+  import.meta.env.VITE_API_URL ||
+  `${location.protocol}//${location.hostname}:3000`;
 export default axios;

--- a/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentForm.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from '../../api';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { FormEvent } from 'react';
 import { useStation } from '../../contexts/StationContext';
 import { DEFECT_CODES } from '../../data/defects';
 
 export default function IncidentForm() {
-  const { station, setStation } = useStation();
+  const { station } = useStation();
   const { data: stations } = useQuery({
     queryKey: ['stations'],
     queryFn: () => axios.get('/stations').then(r => r.data)
@@ -22,6 +22,11 @@ export default function IncidentForm() {
 
   const handle = (e: any) =>
     setForm({ ...form, [e.target.name]: e.target.value });
+
+  // keep form station_id in sync with currently seleccionada station
+  useEffect(() => {
+    setForm(f => ({ ...f, station_id: station }));
+  }, [station]);
 
   const submit = async (e: FormEvent) => {
     e.preventDefault();
@@ -41,24 +46,6 @@ export default function IncidentForm() {
 
   return (
     <form onSubmit={submit} className="space-y-2 border p-4 rounded mt-4">
-      <select
-        value={station}
-        onChange={e => {
-          const val = e.target.value;
-          setStation(val);
-          // default incident station to the current one
-          setForm(f => ({ ...f, station_id: val }));
-        }}
-        className="border p-1 w-full"
-        required
-      >
-        <option value="">ESTACION ACTUAL</option>
-        {stations?.map((s: any) => (
-          <option key={s.id} value={s.id}>
-            {s.name}
-          </option>
-        ))}
-      </select>
 
       <select
         required


### PR DESCRIPTION
## Summary
- make API default to same host as dashboard
- remove duplicate station drop-down in incident form
- sync incident form with selected station
- clarify README instructions for remote access

## Testing
- `npm --prefix andon-server install`
- `npm --prefix andon-server test`

------
https://chatgpt.com/codex/tasks/task_e_685311bf80788333ad503cb7cfa7ddd3