### PR TITLE
Improve Andon dashboard interactions

### DIFF
--- a/andon-client/andon-dashboard/src/components/Dashboard.tsx
+++ b/andon-client/andon-dashboard/src/components/Dashboard.tsx
@@ -1,5 +1,7 @@
 import { useStations } from '../hooks/useStations';
 import { useIncidents } from '../hooks/useIncidents';
+import { useStation } from '../contexts/StationContext';
+import { useNavigate } from 'react-router-dom';
 import { useMqtt } from '../hooks/useMqtt';
 import { useEffect, useState } from 'react';
 
@@ -8,6 +10,8 @@ type Station = { id: string; name: string; color: string };
 export default function Dashboard() {
   const { data: stations } = useStations();
   const { data: incidents } = useIncidents('open');
+  const { setStation } = useStation();
+  const navigate = useNavigate();
   const [view, setView] = useState<Station[]>([]);
 
   useEffect(() => {
@@ -32,15 +36,16 @@ export default function Dashboard() {
   return (
     <div className="grid grid-cols-3 gap-4 p-4">
       {view.map(st => (
-        <div
+        <button
           key={st.id}
-          className={`border p-4 rounded
+          onClick={() => { setStation(String(st.id)); navigate('/incidents'); }}
+          className={`border p-4 rounded text-left w-full
             ${st.color === 'rojo' ? 'bg-red-300' :
               st.color === 'amarillo' ? 'bg-yellow-200' : 'bg-green-200'}`}
         >
           <h2 className="font-bold text-lg">{st.name}</h2>
           <p>{st.color}</p>
-        </div>
+        </button>
       ))}
     </div>
   );

--- a/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
@@ -1,15 +1,30 @@
 import { useIncidents, useIncidentAction } from '../../hooks/useIncidents';
 import { useStation } from '../../contexts/StationContext';
+import { useState } from 'react';
 
 export default function IncidentTable({ status }: { status: string }) {
   const { station } = useStation();
   const { data } = useIncidents(status, station);
+  const [query, setQuery] = useState('');
   const action  = useIncidentAction();
 
   if (!data) return <p>Cargando...</p>;
 
+  const filtered = query
+    ? data.filter((i: any) => i.vehicle_id?.includes(query))
+    : data;
+
   return (
-    <table className="w-full border mt-2">
+    <div className="w-full mt-2">
+      {status !== 'open' && (
+        <input
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="Buscar ID Veh\u00edculo"
+          className="border p-1 mb-2 w-full"
+        />
+      )}
+      <table className="w-full border">
       <thead>
         <tr>
           <th>ID</th><th>ESTACION</th><th>Defecto</th>
@@ -18,7 +33,7 @@ export default function IncidentTable({ status }: { status: string }) {
         </tr>
       </thead>
       <tbody>
-        {data.map((i: any) => (
+        {filtered.map((i: any) => (
           <tr key={i.id} className="text-center">
             <td>{i.id}</td>
             <td>{i.station_id}</td>
@@ -48,5 +63,7 @@ export default function IncidentTable({ status }: { status: string }) {
         ))}
       </tbody>
     </table>
+    {filtered.length === 0 && <p>No hay registros</p>}
+    </div>
   );
 }

--- a/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
@@ -1,11 +1,12 @@
 import IncidentForm from '../components/incidents/IncidentForm';
 import IncidentTable from '../components/incidents/IncidentTable';
+import ChartsPage from './ChartsPage';
 import { useState } from 'react';
 import { useStation } from '../contexts/StationContext';
 import { useIncidentSync } from '../hooks/useIncidentSync';
 
 export default function IncidentsPage() {
-  const [tab, setTab] = useState<'open' | 'closed'>('open');
+  const [tab, setTab] = useState<'open' | 'closed' | 'charts'>('open');
   const { station } = useStation();
   useIncidentSync();
 
@@ -31,9 +32,19 @@ export default function IncidentsPage() {
         >
           Histórico
         </button>
+        <button
+          onClick={() => setTab('charts')}
+          className={`px-4 py-1 ${tab === 'charts' ? 'bg-gray-300' : ''}`}
+        >
+          Gráficas
+        </button>
       </div>
 
-      <IncidentTable status={tab === 'open' ? 'open' : 'all'} />
+      {tab === 'charts' ? (
+        <ChartsPage />
+      ) : (
+        <IncidentTable status={tab === 'open' ? 'open' : 'all'} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- link station buttons to incident dashboard
- add charts tab in incidents page
- filter historic incidents by Vehicle ID

## Testing
- `npm run lint` within `andon-client/andon-dashboard`
- `npm test` within `andon-server`


------
https://chatgpt.com/codex/tasks/task_e_6854c96e93e48333a2470c0a02e19b76