### PR TITLE
Fix incident tabs behaviour

### DIFF
--- a/andon-client/andon-dashboard/src/index.css
+++ b/andon-client/andon-dashboard/src/index.css
@@ -84,6 +84,7 @@ button:focus-visible {
 .bg-yellow-200 { background-color: #f0e68c; }
 .bg-green-200 { background-color: #c6e6c6; }
 .bg-blue-500 { background-color: #4d90fe; }
+.bg-white { background-color: #fff; }
 .w-full { width: 100%; }
 .space-y-2 > * + * { margin-top: 0.5rem; }
 

--- a/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/IncidentsPage.tsx
@@ -18,19 +18,19 @@ export default function IncidentsPage() {
         <div className="flex gap-2">
           <button
             onClick={() => setTab('open')}
-            className={`px-4 py-1 ${tab === 'open' ? 'bg-blue-500 text-white' : ''}`}
+            className={`px-4 py-1 border ${tab === 'open' ? 'bg-blue-500 text-white' : 'bg-white'}`}
           >
             Incidencias Activas
           </button>
           <button
             onClick={() => setTab('closed')}
-            className={`px-4 py-1 ${tab === 'closed' ? 'bg-blue-500 text-white' : ''}`}
+            className={`px-4 py-1 border ${tab === 'closed' ? 'bg-blue-500 text-white' : 'bg-white'}`}
           >
             Historial
           </button>
           <button
             onClick={() => setTab('charts')}
-            className={`px-4 py-1 ${tab === 'charts' ? 'bg-blue-500 text-white' : ''}`}
+            className={`px-4 py-1 border ${tab === 'charts' ? 'bg-blue-500 text-white' : 'bg-white'}`}
           >
             Gráficas
           </button>
@@ -40,7 +40,7 @@ export default function IncidentsPage() {
         <p className="text-red-600">Selecciona una ESTACION para operar.</p>
       )}
 
-      <IncidentForm />
+      {tab === 'open' && <IncidentForm />}
 
       {tab === 'charts' ? (
         <ChartsPage />


### PR DESCRIPTION
## Summary
- show incident form only when the "Incidencias Activas" tab is active
- lighten unselected incident tab buttons by using a white background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854d031e6c083338d38afabb8d5af40