### PR TITLE
Fix incident table actions and history

### DIFF
--- a/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
+++ b/andon-client/andon-dashboard/src/components/incidents/IncidentTable.tsx
@@ -1,4 +1,4 @@
-import { useIncidents } from '../../hooks/useIncidents';
+import { useIncidents, useIncidentAction } from '../../hooks/useIncidents';
 import { useStation } from '../../contexts/StationContext';
 import { useState } from 'react';
 
@@ -6,6 +6,7 @@ export default function IncidentTable({ status }: { status: string }) {
   const { station } = useStation();
   const { data } = useIncidents(status, station);
   const [query, setQuery] = useState('');
+  const action = useIncidentAction();
 
   if (!data) return <p>Cargando...</p>;
 
@@ -26,27 +27,47 @@ export default function IncidentTable({ status }: { status: string }) {
       <table className="w-full border">
       <thead>
         <tr>
-          <th>Quien</th>
-          <th>Origen</th>
+          <th>Estaci\u00f3n</th>
           <th>C\u00f3digo</th>
           <th>Descripci\u00f3n</th>
           <th>ID Veh\u00edculo</th>
-          <th>Fecha</th>
-          <th>Estado</th>
+          <th>Reporte</th>
+          <th>Recibido</th>
+          <th>Reproceso</th>
           <th>Finalizado</th>
+          <th>Estado</th>
         </tr>
       </thead>
       <tbody>
         {filtered.map((i: any) => (
           <tr key={i.id} className="text-center">
             <td>{i.station_id}</td>
-            <td>{i.station_id}</td>
             <td>{i.defect_code}</td>
             <td>{i.problem}</td>
             <td>{i.vehicle_id}</td>
             <td>{i.opened_at && new Date(i.opened_at).toLocaleString()}</td>
-            <td>{i.status}</td>
+            <td>{i.received_at && new Date(i.received_at).toLocaleString()}</td>
+            <td>{i.reprocess_at && new Date(i.reprocess_at).toLocaleString()}</td>
             <td>{i.closed_at && new Date(i.closed_at).toLocaleString()}</td>
+            <td>
+              {i.status === 'open' ? (
+                <select
+                  defaultValue=""
+                  onChange={e => {
+                    const val = e.target.value;
+                    if (val) action.mutate({ id: i.id, action: val });
+                  }}
+                  className="border p-1"
+                >
+                  <option value="">Acci\u00f3n</option>
+                  <option value="recibido">Recibido</option>
+                  <option value="reproceso">Reproceso</option>
+                  <option value="finalizado">Finalizado</option>
+                </select>
+              ) : (
+                i.status
+              )}
+            </td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Summary
- restore incident action dropdown and timestamps in IncidentTable

## Testing
- `cd andon-server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854de3de6708333828b9b36e2d4a3a4