### PR TITLE
Add filter row and dynamic chart layout

### DIFF
--- a/andon-client/andon-dashboard/src/pages/ChartsPage.tsx
+++ b/andon-client/andon-dashboard/src/pages/ChartsPage.tsx
@@ -1,63 +1,120 @@
 // ChartsPage.tsx
-// grafica simple de incidencias por estacion usando Recharts
-import { useIncidents } from '../hooks/useIncidents';
-import { PieChart, Pie, Cell, Tooltip, BarChart, Bar, XAxis, YAxis } from 'recharts';
-import { useStation } from '../contexts/StationContext';
+// vista de graficas con filtros por fecha, estacion y codigo
 import { useState } from 'react';
+import { useIncidents } from '../hooks/useIncidents';
+import { useStations } from '../hooks/useStations';
+import { DEFECT_CODES } from '../data/defects';
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend
+} from 'recharts';
 
 export default function ChartsPage() {
-  const { station } = useStation();
-  const { data, isLoading } = useIncidents('all', station);
-  const [range, setRange] = useState<'all' | '24h' | '7d'>('all');
-  const [type, setType]   = useState<'pie' | 'bar'>('pie');
+  const { data, isLoading } = useIncidents('all');
+  const { data: stations } = useStations();
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [st, setSt] = useState('all');
+  const [def, setDef] = useState('all');
+  const [type, setType] = useState<'bar' | 'line'>('bar');
 
-  if (isLoading) return <p>Cargando...</p>;
+  if (isLoading || !stations) return <p>Cargando...</p>;
   if (!data?.length) return <p>No hay datos.</p>;
 
-  const now = Date.now();
   const filtered = data.filter((i: any) => {
-    const t = new Date(i.opened_at).getTime();
-    if(range === '24h') return now - t <= 86400000;
-    if(range === '7d')  return now - t <= 604800000;
+    const d = new Date(i.opened_at);
+    if (from && d < new Date(from)) return false;
+    if (to && d > new Date(to + 'T23:59:59')) return false;
+    if (st !== 'all' && String(i.station_id) !== st) return false;
+    if (def !== 'all' && i.defect_code !== def) return false;
     return true;
   });
 
-  // cuenta incidencias por estacion
   const counts: Record<string, number> = {};
-  filtered.forEach((i: any) =>
-    counts[i.station_id] = (counts[i.station_id] || 0) + 1
-  );
-
-  const chartData = Object.entries(counts).map(([name, value]) => ({ name, value }));
+  filtered.forEach((i: any) => {
+    const day = String(i.opened_at).slice(0, 10);
+    counts[day] = (counts[day] || 0) + 1;
+  });
+  const chartData = Object.entries(counts)
+    .map(([date, count]) => ({ date, count }))
+    .sort((a, b) => a.date.localeCompare(b.date));
 
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Incidencias por ESTACION</h1>
-      <div className="flex gap-2 mb-4">
-        <select value={range} onChange={e => setRange(e.target.value as any)} className="border p-1">
+    <div className="space-y-2">
+      <div className="flex gap-2 mb-2">
+        <input
+          type="date"
+          value={from}
+          onChange={e => setFrom(e.target.value)}
+          className="border p-1"
+        />
+        <input
+          type="date"
+          value={to}
+          onChange={e => setTo(e.target.value)}
+          className="border p-1"
+        />
+        <select
+          value={st}
+          onChange={e => setSt(e.target.value)}
+          className="border p-1"
+        >
           <option value="all">Todas</option>
-          <option value="24h">\u00dAltimas 24h</option>
-          <option value="7d">\u00dAltima semana</option>
+          {stations.map((s: any) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
         </select>
-        <select value={type} onChange={e => setType(e.target.value as any)} className="border p-1">
-          <option value="pie">Pastel</option>
+        <select
+          value={def}
+          onChange={e => setDef(e.target.value)}
+          className="border p-1"
+        >
+          <option value="all">Todos</option>
+          {DEFECT_CODES.map(d => (
+            <option key={d.code} value={d.code}>
+              {d.code}-{d.description}
+            </option>
+          ))}
+        </select>
+        <select
+          value={type}
+          onChange={e => setType(e.target.value as 'bar' | 'line')}
+          className="border p-1 ml-auto"
+        >
           <option value="bar">Barras</option>
+          <option value="line">Líneas</option>
         </select>
       </div>
-      {type === 'pie' ? (
-        <PieChart width={400} height={300}>
-          <Pie data={chartData} dataKey="value" nameKey="name" outerRadius={120}>
-            {chartData.map((_, idx) => <Cell key={idx} />)}
-          </Pie>
-          <Tooltip />
-        </PieChart>
-      ) : (
-        <BarChart width={400} height={300} data={chartData}>
-          <XAxis dataKey="name" /><YAxis />
-          <Tooltip />
-          <Bar dataKey="value" />
-        </BarChart>
-      )}
+      <div className="border-2 border-dashed p-4 bg-white">
+        <ResponsiveContainer width="100%" height={300}>
+          {type === 'bar' ? (
+            <BarChart data={chartData}>
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="count" fill="#8884d8" />
+            </BarChart>
+          ) : (
+            <LineChart data={chartData}>
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Legend />
+              <Line type="monotone" dataKey="count" stroke="#8884d8" />
+            </LineChart>
+          )}
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update charts page with date, station and error filters
- render bar or line chart inside dashed container

## Testing
- `npm test` in `andon-server`
- `npm run build` in `andon-client/andon-dashboard`


------
https://chatgpt.com/codex/tasks/task_e_6854e5c83ef88333b3af8429c308c38d